### PR TITLE
Generate correct path key for typed path parameters

### DIFF
--- a/lib/parseEndpoints.js
+++ b/lib/parseEndpoints.js
@@ -271,7 +271,7 @@ function buildBodyParam(bodyParamsStr) {
 }
 
 function buildPathKey(pathStr, group) {
-  return `${pathStr.replace(/:(.*?)(\/|$)/g, '{$1}$2')}${group}`;
+  return `${pathStr.replace(/:([^:/]+)(?::[^/]+)?(\/|$)/g, '{$1}$2')}${group}`;
 }
 
 module.exports = toOpenapi;

--- a/tests/endpoints/expectations/complex.paths.json
+++ b/tests/endpoints/expectations/complex.paths.json
@@ -4,7 +4,7 @@
       "patch": {
         "summary": "Update resources",
         "description": "Update resources",
-        "operationId": "PATCH--parent--a--resources--b--variant",
+        "operationId": "PATCH--parent--a--resources--b--integer--variant",
         "responses": {
           "200": {
             "description": "",
@@ -40,7 +40,7 @@
           {
             "name": "b",
             "required": true,
-            "type": "string",
+            "type": "integer",
             "in": "path"
           },
           {

--- a/tests/endpoints/sources/complex.endpoints.tinyspec
+++ b/tests/endpoints/sources/complex.endpoints.tinyspec
@@ -2,6 +2,6 @@
 
 My tag:
     // Update resources
-    @token PATCH /parent/:a/resources/:b (variant)?c&d?&e:boolean {f, g?, h: i[]}
+    @token PATCH /parent/:a/resources/:b:integer (variant)?c&d?&e:boolean {f, g?, h: i[]}
         => 200 {resource: Resource} # Another comment
         => 404 NotFoundError


### PR DESCRIPTION
Path parameters can be typed (`/some/:param:integer`); they are parsed and the parameter type is taken into account, but the resulting path key in the output contains the entire parameter specification (`name:type`) which is obviously incorrect.

This PR modifies the code to strip the type and the preceding semicolon from the path key.
