### PR TITLE
Allow specifying Operation IDs

### DIFF
--- a/lib/parseEndpoints.js
+++ b/lib/parseEndpoints.js
@@ -57,22 +57,23 @@ function toOpenapi(text) {
       return;
     }
 
-    const match = line.match(/\s*(@\w+ )?([A-Z]+) ([/\w_:]+)( \([\w_]+\))?(\?[^\s]+)?( (.+))?/);
+    const match = line.match(/\s*(?:([\w_-]+)\s*=\s*)?(@\w+ )?([A-Z]+) ([/\w_:]+)( \([\w_]+\))?(\?[^\s]+)?( (.+))?/);
 
     if (!match) {
       throw new Error(`Invalid definition: \`${line}\``);
     }
 
-    const authMethod = match[1] && match[1].replace(/[@\s]/g, '');
-    const method = match[2];
-    let path = match[3];
-    const group = match[4] || '';
-    const pathParams = match[3].match(/\/:.*?(\/|$)/g);
-    const queryParams = match[5] && match[5].replace('?', '').split('&');
-    const bodyParams = match[7];
+    const explicitOperationId = match[1] || '';
+    const authMethod = match[2] && match[2].replace(/[@\s]/g, '');
+    const method = match[3];
+    let path = match[4];
+    const group = match[5] || '';
+    const pathParams = match[4].match(/\/:.*?(\/|$)/g);
+    const queryParams = match[6] && match[6].replace('?', '').split('&');
+    const bodyParams = match[8];
     const parameters = [];
     const signature = `${method} ${path}${group}`;
-    const operationId = signature.replace(/[^\w_-]+/g, '--').replace(/[^\w]+$/, '');
+    const operationId = explicitOperationId || signature.replace(/[^\w_-]+/g, '--').replace(/[^\w]+$/, '');
     const title = currentDescription.length ? currentDescription[0] : signature;
     const summary = removeMarkdownLinks(title);
     const description = currentDescription.length > 1 ? currentDescription.join('\n\n') : title;

--- a/tests/endpoints/expectations/complex.paths.json
+++ b/tests/endpoints/expectations/complex.paths.json
@@ -4,7 +4,7 @@
       "patch": {
         "summary": "Update resources",
         "description": "Update resources",
-        "operationId": "PATCH--parent--a--resources--b--integer--variant",
+        "operationId": "updateResources",
         "responses": {
           "200": {
             "description": "",

--- a/tests/endpoints/sources/complex.endpoints.tinyspec
+++ b/tests/endpoints/sources/complex.endpoints.tinyspec
@@ -2,6 +2,6 @@
 
 My tag:
     // Update resources
-    @token PATCH /parent/:a/resources/:b:integer (variant)?c&d?&e:boolean {f, g?, h: i[]}
+    updateResources = @token PATCH /parent/:a/resources/:b:integer (variant)?c&d?&e:boolean {f, g?, h: i[]}
         => 200 {resource: Resource} # Another comment
         => 404 NotFoundError


### PR DESCRIPTION
Operation definitions can now start with `<OperationId> = ` to provide Operation IDs instead of automatically generated ones.

Closes #14.