### PR TITLE
Generate Operation IDs when expanding $CRUDL definitions

### DIFF
--- a/lib/parseEndpoints.js
+++ b/lib/parseEndpoints.js
@@ -169,8 +169,9 @@ function handleCrudl(line) {
   const useSubModels = _.endsWith(modelName, '$');
   const baseModelName = useSubModels ? modelName.replace(/\$$/, '') : modelName;
 
-  const entity = `_${keyName}_`;
-  const entityPlural = `_${keyNamePlural}_`;
+  const entity = keyName;
+  const entityPlural = keyNamePlural;
+
   const members = getCrudlMembers({
     path, keyName, keyNamePlural, entity, entityPlural, baseModelName, prefix, group, useSubModels,
   });
@@ -181,30 +182,32 @@ function handleCrudl(line) {
 function getCrudlMembers({
   path, keyName, keyNamePlural, entity, entityPlural, baseModelName, prefix = '', group = '', useSubModels,
 }) {
+  const entityForId = _.upperFirst(entity);
+  const entityPluralForId = _.upperFirst(entityPlural);
   return {
     C: `
-    // **Create** new ${entity}
-    ${prefix}POST ${path}${group} {${keyName}: ${baseModelName}${useSubModels ? 'New' : ''}}
+    // **Create** new _${entity}_
+    create${entityForId} = ${prefix}POST ${path}${group} {${keyName}: ${baseModelName}${useSubModels ? 'New' : ''}}
         => 201 {${keyName}: ${baseModelName}}
 `,
     R: `
-    // **Retrieve** ${entity}
-    ${prefix}GET ${path}/:id${group}
+    // **Retrieve** _${entity}_
+    retrieve${entityForId} = ${prefix}GET ${path}/:id${group}
         => {${keyName}: ${baseModelName}}
 `,
     U: `
-    // **Update** ${entity}
-    ${prefix}PATCH ${path}/:id${group} {${keyName}: ${baseModelName}${useSubModels ? 'Update' : ''}}
+    // **Update** _${entity}_
+    update${entityForId} = ${prefix}PATCH ${path}/:id${group} {${keyName}: ${baseModelName}${useSubModels ? 'Update' : ''}}
         => {${keyName}: ${baseModelName}}
 `,
     D: `
-    // **Delete** ${entity}
-    ${prefix}DELETE ${path}/:id${group}
+    // **Delete** _${entity}_
+    delete${entityForId} = ${prefix}DELETE ${path}/:id${group}
         => {success: b}
 `,
     L: `
-    // **List** ${entityPlural}
-    ${prefix}GET ${path}${group}
+    // **List** _${entityPlural}_
+    list${entityPluralForId} = ${prefix}GET ${path}${group}
         => {${keyNamePlural}: ${baseModelName}[]}
 `,
   };

--- a/tests/endpoints/expectations/crudlBasic.paths.json
+++ b/tests/endpoints/expectations/crudlBasic.paths.json
@@ -4,7 +4,7 @@
       "get": {
         "summary": "**List** _my1Resources_",
         "description": "**List** _my1Resources_",
-        "operationId": "GET--my1Resources",
+        "operationId": "listMy1Resources",
         "responses": {
           "200": {
             "description": "",
@@ -28,7 +28,7 @@
       "post": {
         "summary": "**Create** new _my1Resource_",
         "description": "**Create** new _my1Resource_",
-        "operationId": "POST--my1Resources",
+        "operationId": "createMy1Resource",
         "responses": {
           "201": {
             "description": "",
@@ -69,7 +69,7 @@
       "get": {
         "summary": "**Retrieve** _my1Resource_",
         "description": "**Retrieve** _my1Resource_",
-        "operationId": "GET--my1Resources--id",
+        "operationId": "retrieveMy1Resource",
         "responses": {
           "200": {
             "description": "",
@@ -98,7 +98,7 @@
       "patch": {
         "summary": "**Update** _my1Resource_",
         "description": "**Update** _my1Resource_",
-        "operationId": "PATCH--my1Resources--id",
+        "operationId": "updateMy1Resource",
         "responses": {
           "200": {
             "description": "",
@@ -143,7 +143,7 @@
       "delete": {
         "summary": "**Delete** _my1Resource_",
         "description": "**Delete** _my1Resource_",
-        "operationId": "DELETE--my1Resources--id",
+        "operationId": "deleteMy1Resource",
         "responses": {
           "200": {
             "description": "",
@@ -174,7 +174,7 @@
       "post": {
         "summary": "**Create** new _my2Resource_",
         "description": "**Create** new _my2Resource_",
-        "operationId": "POST--my2Resources",
+        "operationId": "createMy2Resource",
         "responses": {
           "201": {
             "description": "",
@@ -215,7 +215,7 @@
       "delete": {
         "summary": "**Delete** _my2Resource_",
         "description": "**Delete** _my2Resource_",
-        "operationId": "DELETE--my2Resources--id",
+        "operationId": "deleteMy2Resource",
         "responses": {
           "200": {
             "description": "",

--- a/tests/endpoints/expectations/crudlCustomModels.paths.json
+++ b/tests/endpoints/expectations/crudlCustomModels.paths.json
@@ -4,7 +4,7 @@
       "get": {
         "summary": "**List** _customKeys_",
         "description": "**List** _customKeys_",
-        "operationId": "GET--my1Resources",
+        "operationId": "listCustomKeys",
         "responses": {
           "200": {
             "description": "",
@@ -28,7 +28,7 @@
       "post": {
         "summary": "**Create** new _customKey_",
         "description": "**Create** new _customKey_",
-        "operationId": "POST--my1Resources",
+        "operationId": "createCustomKey",
         "responses": {
           "201": {
             "description": "",
@@ -69,7 +69,7 @@
       "get": {
         "summary": "**Retrieve** _customKey_",
         "description": "**Retrieve** _customKey_",
-        "operationId": "GET--my1Resources--id",
+        "operationId": "retrieveCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -98,7 +98,7 @@
       "patch": {
         "summary": "**Update** _customKey_",
         "description": "**Update** _customKey_",
-        "operationId": "PATCH--my1Resources--id",
+        "operationId": "updateCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -143,7 +143,7 @@
       "delete": {
         "summary": "**Delete** _customKey_",
         "description": "**Delete** _customKey_",
-        "operationId": "DELETE--my1Resources--id",
+        "operationId": "deleteCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -174,7 +174,7 @@
       "get": {
         "summary": "**List** _customKeys_",
         "description": "**List** _customKeys_",
-        "operationId": "GET--my2Resources",
+        "operationId": "listCustomKeys",
         "responses": {
           "200": {
             "description": "",
@@ -198,7 +198,7 @@
       "post": {
         "summary": "**Create** new _customKey_",
         "description": "**Create** new _customKey_",
-        "operationId": "POST--my2Resources",
+        "operationId": "createCustomKey",
         "responses": {
           "201": {
             "description": "",
@@ -239,7 +239,7 @@
       "get": {
         "summary": "**Retrieve** _customKey_",
         "description": "**Retrieve** _customKey_",
-        "operationId": "GET--my2Resources--id",
+        "operationId": "retrieveCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -268,7 +268,7 @@
       "patch": {
         "summary": "**Update** _customKey_",
         "description": "**Update** _customKey_",
-        "operationId": "PATCH--my2Resources--id",
+        "operationId": "updateCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -313,7 +313,7 @@
       "delete": {
         "summary": "**Delete** _customKey_",
         "description": "**Delete** _customKey_",
-        "operationId": "DELETE--my2Resources--id",
+        "operationId": "deleteCustomKey",
         "responses": {
           "200": {
             "description": "",
@@ -344,7 +344,7 @@
       "get": {
         "summary": "**List** _my3Resources_",
         "description": "**List** _my3Resources_",
-        "operationId": "GET--my3Resources",
+        "operationId": "listMy3Resources",
         "responses": {
           "200": {
             "description": "",
@@ -368,7 +368,7 @@
       "post": {
         "summary": "**Create** new _my3Resource_",
         "description": "**Create** new _my3Resource_",
-        "operationId": "POST--my3Resources",
+        "operationId": "createMy3Resource",
         "responses": {
           "201": {
             "description": "",
@@ -409,7 +409,7 @@
       "get": {
         "summary": "**Retrieve** _my3Resource_",
         "description": "**Retrieve** _my3Resource_",
-        "operationId": "GET--my3Resources--id",
+        "operationId": "retrieveMy3Resource",
         "responses": {
           "200": {
             "description": "",
@@ -438,7 +438,7 @@
       "patch": {
         "summary": "**Update** _my3Resource_",
         "description": "**Update** _my3Resource_",
-        "operationId": "PATCH--my3Resources--id",
+        "operationId": "updateMy3Resource",
         "responses": {
           "200": {
             "description": "",
@@ -483,7 +483,7 @@
       "delete": {
         "summary": "**Delete** _my3Resource_",
         "description": "**Delete** _my3Resource_",
-        "operationId": "DELETE--my3Resources--id",
+        "operationId": "deleteMy3Resource",
         "responses": {
           "200": {
             "description": "",

--- a/tests/endpoints/expectations/crudlOverride.paths.json
+++ b/tests/endpoints/expectations/crudlOverride.paths.json
@@ -4,7 +4,7 @@
       "get": {
         "summary": "**List** _my1Resources_",
         "description": "**List** _my1Resources_",
-        "operationId": "GET--my1Resources",
+        "operationId": "listMy1Resources",
         "responses": {
           "200": {
             "description": "",
@@ -30,7 +30,7 @@
       "get": {
         "summary": "**Retrieve** _my1Resource_",
         "description": "**Retrieve** _my1Resource_",
-        "operationId": "GET--my1Resources--id",
+        "operationId": "retrieveMy1Resource",
         "responses": {
           "200": {
             "description": "",


### PR DESCRIPTION
Operations generated by expanding $CRUDL definitions gain Operation IDs based on entity name (which is the same as payload key name): `createEntity`, `retrieveEntity`, `updateEntity`, `deleteEntity`, `listEntities`.