### PR TITLE
Fix multilevel inheritance

### DIFF
--- a/lib/parseModels.js
+++ b/lib/parseModels.js
@@ -73,13 +73,20 @@ function toOpenapi(text, options) {
         throw new Error(`Parent model object not found for \`${modelName} < ${parentModelName}\``);
       }
 
-      inherit(modelSchema, models[parentModelName]);
+      inherit(modelSchema, parentModelName, models, inheritances);
     }));
 
   return data;
 }
 
-function inherit(child, parent) {
+function inherit(child, parentModelName, models, inheritances) {
+  const parent = models[parentModelName];
+  const grandParentModelName = inheritances[parentModelName];
+
+  if (grandParentModelName) {
+    inherit(parent, grandParentModelName, models, inheritances);
+  }
+
   const selfFields = child.properties ? Object.keys(child.properties) : [];
   const removalIndicators = selfFields.filter(name => _.startsWith(name, '-'));
   const removedFields = removalIndicators.map(field => field.substring(1));

--- a/tests/models/expectations/inheritance.definitions.json
+++ b/tests/models/expectations/inheritance.definitions.json
@@ -130,6 +130,51 @@
       "required": [
         "a"
       ]
+    },
+    "MyModel10": {
+      "type": "object",
+      "properties": {
+        "c": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        },
+        "a": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "c",
+        "b",
+        "a"
+      ]
+    },
+    "MyModel11": {
+      "type": "object",
+      "properties": {
+        "c": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "c",
+        "b"
+      ]
+    },
+    "MyModel12": {
+      "type": "object",
+      "properties": {
+        "c": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "c"
+      ]
     }
   }
 }

--- a/tests/models/sources/inheritance.models.tinyspec
+++ b/tests/models/sources/inheritance.models.tinyspec
@@ -16,3 +16,8 @@ MyModel7 < MyModel6 {b}
 # When parent modal is defined after child model
 MyModel8 < MyModel9
 MyModel9 {a}
+
+# Inheritance chain when parent modal is defined after child model
+MyModel10 < MyModel11 {a}
+MyModel11 < MyModel12 {b}
+MyModel12 {c}


### PR DESCRIPTION
Fixes the following case:

```
MyModel10 < MyModel11 {a}
MyModel11 < MyModel12 {b}
MyModel12 {c}
```